### PR TITLE
Add Dockerfile for Dockerized application startup

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+.git
+.gitignore
+Dockerfile
+.dockerignore
+target
+*.log
+.idea
+.vscode
+*.iml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# syntax=docker/dockerfile:1
+
+FROM maven:3.8.8-eclipse-temurin-11 AS build
+WORKDIR /app
+
+COPY pom.xml ./
+RUN mvn -B -DskipTests dependency:go-offline
+
+COPY src ./src
+RUN mvn -B -DskipTests package
+
+FROM eclipse-temurin:11-jre
+WORKDIR /app
+
+RUN useradd --create-home --shell /usr/sbin/nologin appuser
+
+COPY --from=build /app/target/philipp-skillbox-1.0.jar ./app.jar
+
+USER appuser
+EXPOSE 8080
+
+ENV JAVA_OPTS=""
+ENTRYPOINT ["sh", "-c", "exec java $JAVA_OPTS -jar app.jar"]


### PR DESCRIPTION
### Motivation

- Provide a reproducible Docker image for building and running the Spring Boot application with Java 11 to simplify containerized deployment.

### Description

- Add a multi-stage `Dockerfile` that builds the Maven project in `maven:3.8.8-eclipse-temurin-11` and runs the packaged JAR on `eclipse-temurin:11-jre`, copying the produced `target/philipp-skillbox-1.0.jar` as `app.jar` and using `mvn -DskipTests package` in the build stage.
- Run the container as a non-root user `appuser`, expose port `8080`, provide `JAVA_OPTS` environment variable and use `exec java $JAVA_OPTS -jar app.jar` as the entrypoint for proper signal handling.
- Add `.dockerignore` to exclude VCS metadata, build output, logs and IDE files from the Docker build context.

### Testing

- Ran the build locally with `mvn -B -DskipTests package`, which completed successfully (artifact produced and `BUILD SUCCESS` was reported) and tests were skipped per the flag.
- Attempted `docker build -t myskillboxproject:dockerfile-test .` but the command could not be executed in the environment because Docker was not installed (`docker: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a8ffd120c8327ad84ba8ec0cf1e64)