### PR TITLE
Обновление Maven‑плагинов и зависимостей (Spring Boot 2.7.18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,25 +10,32 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.2.4.RELEASE</version>
+    <version>2.7.18</version>
     <relativePath/>
   </parent>
+
+  <properties>
+    <java.version>11</java.version>
+    <maven.compiler.release>${java.version}</maven.compiler.release>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <mapstruct.version>1.6.3</mapstruct.version>
+  </properties>
 
   <build>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.14.0</version>
         <configuration>
-          <source>11</source>
-          <target>11</target>
+          <release>${maven.compiler.release}</release>
         </configuration>
       </plugin>
       <plugin>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-maven-plugin</artifactId>
-        <version>3.5.5</version>
+        <version>4.31.1</version>
         <configuration>
           <changeLogFile>src/main/resources/database_changelog.xml</changeLogFile>
           <driver>com.mysql.cj.jdbc.Driver</driver>
@@ -49,13 +56,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
-        <version>2.8</version>
+        <version>3.8.1</version>
         <configuration>
           <outputDirectory>${project.build.directory}/lib/</outputDirectory>
           <overWriteReleases>true</overWriteReleases>
           <overWriteSnapshots>true</overWriteSnapshots>
           <overWriteIfNewer>true</overWriteIfNewer>
-
         </configuration>
         <executions>
           <execution>
@@ -65,14 +71,12 @@
               <goal>copy-dependencies</goal>
             </goals>
           </execution>
-
         </executions>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.4</version>
-
+        <version>3.4.2</version>
         <configuration>
           <archive>
             <manifest>
@@ -87,13 +91,12 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
+        <version>3.3.1</version>
       </plugin>
-
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.12</version>
+        <version>0.8.13</version>
         <executions>
           <execution>
             <goals>
@@ -142,8 +145,8 @@
               <additionalProperties>
                 <encoding.source>${project.build.sourceEncoding}</encoding.source>
                 <encoding.reporting>${project.reporting.outputEncoding}</encoding.reporting>
-                <java.source>${maven.compiler.source}</java.source>
-                <java.target>${maven.compiler.target}</java.target>
+                <java.source>${maven.compiler.release}</java.source>
+                <java.target>${maven.compiler.release}</java.target>
               </additionalProperties>
             </configuration>
           </execution>
@@ -152,82 +155,62 @@
     </plugins>
   </build>
 
-  <properties>
-    <java.version>11</java.version>
-    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <version>2.5.12</version>
-    </dependency>
-    <dependency>
-      <groupId>mysql</groupId>
-      <artifactId>mysql-connector-java</artifactId>
-      <version>8.0.28</version>
-    </dependency>
-    <dependency>
-      <groupId>org.junit.jupiter</groupId>
-      <artifactId>junit-jupiter-engine</artifactId>
-      <version>5.4.0</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-jpa</artifactId>
-      <version>2.2.4.RELEASE</version>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-core</artifactId>
-      <version>6.0.0.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>org.projectlombok</groupId>
-      <artifactId>lombok</artifactId>
-      <version>1.18.32</version>
-      <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate</groupId>
-      <artifactId>hibernate-entitymanager</artifactId>
-      <version>5.2.3.Final</version>
-    </dependency>
-    <dependency>
-      <groupId>org.liquibase</groupId>
-      <artifactId>liquibase-core</artifactId>
-      <version>4.8.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.mapstruct</groupId>
-      <artifactId>mapstruct</artifactId>
-      <version>1.3.1.Final</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-mail</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-thymeleaf</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.mysql</groupId>
+      <artifactId>mysql-connector-j</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.liquibase</groupId>
+      <artifactId>liquibase-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mapstruct</groupId>
+      <artifactId>mapstruct</artifactId>
+      <version>${mapstruct.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.javassist</groupId>
+      <artifactId>javassist</artifactId>
+      <version>3.30.2-GA</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-taglibs</artifactId>
-      <version>5.2.0.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>javax.servlet</groupId>
       <artifactId>jstl</artifactId>
-      <version>1.2</version>
     </dependency>
     <dependency>
       <groupId>org.apache.tomcat.embed</groupId>
       <artifactId>tomcat-embed-jasper</artifactId>
-      <version>9.0.27</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-mail</artifactId>
     </dependency>
     <!-- https://mvnrepository.com/artifact/org.imgscalr/imgscalr-lib -->
     <dependency>
@@ -236,51 +219,19 @@
       <version>4.2</version>
     </dependency>
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-test</artifactId>
-      <version>2.2.2.RELEASE</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-test</artifactId>
-      <version>5.2.2.RELEASE</version>
-    </dependency>
-    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.6.0</version>
     </dependency>
-     <dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-thymeleaf</artifactId>
-      <version>2.1.3.RELEASE</version>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-test</artifactId>
-      <version>5.2.1.RELEASE</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <version>3.4.6</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-junit-jupiter</artifactId>
-      <version>3.4.6</version>
-      <scope>test</scope>
-    </dependency>
-
-
   </dependencies>
-
 </project>


### PR DESCRIPTION
### Motivation
- Актуализировать Spring Boot и плагины сборки для совместимости и безопасности сборки.  
- Перейти на единое управление версиями зависимостей через Spring Boot BOM и упростить дублирующие версии в POM.  
- Исправить ошибки сборки/компиляции из-за отсутствующей библиотеки для `javassist.NotFoundException` и обеспечить корректную работу тестов.

### Description
- Обновлён Spring Boot parent с `2.2.4.RELEASE` до `2.7.18` и добавлены свойства проекта (`maven.compiler.release`, `mapstruct.version`, кодировка).  
- Обновлены версии Maven‑плагинов: `maven-compiler-plugin` -> `3.14.0` (использует `<release>`), `liquibase-maven-plugin` -> `4.31.1`, `maven-dependency-plugin` -> `3.8.1`, `maven-jar-plugin` -> `3.4.2`, `maven-resources-plugin` -> `3.3.1`, `jacoco-maven-plugin` -> `0.8.13`.  
- Упрощены и перераспределены зависимости под управление Spring Boot (перенесены стартовые артефакты в корректные места), заменён MySQL connector на `com.mysql:mysql-connector-j` с `runtime` scope и вынесен `mapstruct` в свойство.  
- Добавлена явная зависимость `org.javassist:javassist:3.30.2-GA` для существующих ссылок на `javassist.NotFoundException`, а тестовые зависимости консолидированы через `spring-boot-starter-test` и `spring-security-test`.

### Testing
- Запуск валидации прошёл успешно с `mvn -q -DskipTests validate`.  
- Полный набор тестов запущен командой `mvn test` и завершился успешно (`BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da960c0dc8327b129ff5c7e44859e)